### PR TITLE
clas-stringspinner: new version 0.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ bin
 lib
 lib64
 include
-etc
 share
 *.dat
 *.root

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ fixperms:
 	chmod -R +r onepigen/spp_tbl
 
 clean:
-	rm -rf bin lib lib64 build share include etc
+	rm -rf bin lib lib64 build share include
 	for dir in $(CLEANDIRS); do\
 		$(MAKE) -C $$dir clean; \
 	done

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ name | compilation and executable name | CLI options | runs in container w/ outp
 ---- | ------------------------------- | --------------------- | -----------------
 clasdis | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 claspyth | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-classtringspinner | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+clas-stringspinner | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 dvcsgen | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 genKYandOnePion | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 inclusive-dis-rad | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/versions.json
+++ b/versions.json
@@ -13,5 +13,5 @@
     "genepi" :            "v1.2",
     "onepigen" :          "v1.2",
     "GiBUU" :             "2023",
-    "clas-stringspinner": "v0.1.0"
+    "clas-stringspinner": "v0.1.1"
 }


### PR DESCRIPTION
This fixes a bug where the OSG runtime cannot find the steer files. I'm not able to reproduce the bug on _any_ machine, so I decided to convert the steer file into a C++ function. The installed `etc/` directory is no longer needed.

Details: https://github.com/JeffersonLab/clas-stringspinner/releases/tag/v0.1.1