### PR TITLE
ci: generate `clas-stringspinner` documentation for the highest `clas12-mcgen` tag

### DIFF
--- a/.github/get_highest_tag.rb
+++ b/.github/get_highest_tag.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# gets the tag with the highest semver number
+# - "highest" is preferred over "latest", because of backports to old tags may
+#   cause them to be "later" than "higher" tags
+
+if ARGV.empty?
+  $stderr.puts "USAGE: #{$0} [repo owner]/[repo name]"
+  exit 2
+end
+repo = ARGV[0]
+
+api_args = [
+  '--silent',
+  '-L',
+  '-H "Accept: application/vnd.github+json"',
+  '-H "X-GitHub-Api-Version: 2022-11-28"',
+  "https://api.github.com/repos/#{repo}/tags",
+]
+tag_list_unsorted = `curl #{api_args.join ' '} | jq -r '.[].name'`
+unless $?.success?
+  $stderr.puts "ERROR: failed to get highest tag from repository '#{repo}'"
+  exit 1
+end
+
+tag_list = tag_list_unsorted.split.map{ |tag|
+  begin
+    Gem::Version.new tag.gsub(/^v/,'')
+  rescue
+    nil
+  end
+}.compact.sort.reverse.map &:to_s
+
+if tag_list.empty?
+  $stderr.puts "ERROR: no semver tags found"
+  exit 1
+end
+
+puts tag_list.first

--- a/.github/get_highest_tag.rb
+++ b/.github/get_highest_tag.rb
@@ -24,15 +24,15 @@ end
 
 tag_list = tag_list_unsorted.split.map{ |tag|
   begin
-    Gem::Version.new tag.gsub(/^v/,'')
+    [ Gem::Version.new(tag.gsub(/^v/,'')), tag ]
   rescue
     nil
   end
-}.compact.sort.reverse.map &:to_s
+}.compact.sort_by{|a|a.first}.reverse
 
 if tag_list.empty?
   $stderr.puts "ERROR: no semver tags found"
   exit 1
 end
 
-puts tag_list.first
+puts tag_list.first.last

--- a/.github/index.html
+++ b/.github/index.html
@@ -1,0 +1,11 @@
+<!-- index page for generated documentation -->
+<html>
+  <head>
+    <title>clas12-mcgen documentation</title>
+  </head>
+  <body>
+    <ul>
+      <li><a href="clas-stringspinner.html">clas-stringspinner</a></li>
+    </ul>
+  </body>
+</html>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  generate_documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: tmp
+      - name: get latest tag
+        id: tag
+        run: |
+          tag=$(.github/get_highest_tag.rb ${{ github.repository }})
+          echo $tag
+          echo tag=$tag >> $GITHUB_OUTPUT
+          rm -rf tmp
+      - name: checkout latest tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          submodules: recursive
+      - name: build
+        run: make clas-stringspinner -j4
+      - name: generate documentation
+        run: |
+          mkdir publish
+          cp .github/index.html publish/
+          clas-stringspinner/.github/generate_usage_guide.sh bin/clas-stringspinner > publish/clas-stringspinner.html
+      - name: upload documentation
+        uses: actions/upload-pages-artifact@v3
+        with:
+          retention-days: 3
+          path: publish/
+
+  deploy_webpages:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: generate_documentation
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: deployment
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           ref: ${{ steps.tag.outputs.tag }}
           submodules: recursive
           fetch-tags: true
+          clean: false
+          fetch-depth: 0
       - name: build
         run: make clas-stringspinner -j4
       - name: generate documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: get latest tag
         id: tag
         run: |
-          tag=$(tmp/.github/get_highest_tag.rb JeffersonLab/clas12-mcgen
+          tag=$(tmp/.github/get_highest_tag.rb JeffersonLab/clas12-mcgen)
           echo $tag
           echo tag=$tag >> $GITHUB_OUTPUT
           rm -rf tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
           repository: JeffersonLab/clas12-mcgen ###############FIXME DELETE!!!
           ref: ${{ steps.tag.outputs.tag }}
           submodules: recursive
-          fetch-tags: true
-          clean: false
-          fetch-depth: 0
+          # fetch-tags: true
+          # clean: false
+          # fetch-depth: 0
       - name: build
         run: make clas-stringspinner -j4
       - name: generate documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: get latest tag
         id: tag
         run: |
-          tag=$(tmp/.github/get_highest_tag.rb ${{ github.repository }})
+          tag=$(tmp/.github/get_highest_tag.rb JeffersonLab/clas12-mcgen
           echo $tag
           echo tag=$tag >> $GITHUB_OUTPUT
           rm -rf tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+# FIXME: this will run on PRs, so we know more quickly when it fails; alternatively, if
+# we only want this to be triggered on 'push', we should make failures open up issues
+# (see, for example, `clas12-validation`)
+
 on:
   pull_request:
   push:
@@ -32,12 +36,11 @@ jobs:
       - name: checkout latest tag
         uses: actions/checkout@v4
         with:
-          repository: JeffersonLab/clas12-mcgen ###############FIXME DELETE!!!
+          repository: JeffersonLab/clas12-mcgen # only the main fork has tags
           ref: ${{ steps.tag.outputs.tag }}
           submodules: recursive
-          # fetch-tags: true
-          # clean: false
-          # fetch-depth: 0
+      - name: install dependencies
+        run: sudo apt install meson ninja
       - name: build
         run: make clas-stringspinner -j4
       - name: generate documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - name: checkout latest tag
         uses: actions/checkout@v4
         with:
+          repository: JeffersonLab/clas12-mcgen ###############FIXME DELETE!!!
           ref: ${{ steps.tag.outputs.tag }}
           submodules: recursive
           fetch-tags: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: get latest tag
         id: tag
         run: |
-          tag=$(.github/get_highest_tag.rb ${{ github.repository }})
+          tag=$(tmp/.github/get_highest_tag.rb ${{ github.repository }})
           echo $tag
           echo tag=$tag >> $GITHUB_OUTPUT
           rm -rf tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
           submodules: recursive
+          fetch-tags: true
       - name: build
         run: make clas-stringspinner -j4
       - name: generate documentation

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: CI
+name: documentation
 
 # FIXME: this will run on PRs, so we know more quickly when it fails; alternatively, if
 # we only want this to be triggered on 'push', we should make failures open up issues

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ steps.tag.outputs.tag }}
           submodules: recursive
       - name: install dependencies
-        run: sudo apt install meson ninja
+        run: sudo apt -y install meson
       - name: build
         run: make clas-stringspinner -j4
       - name: generate documentation

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -23,6 +23,8 @@ jobs:
   generate_documentation:
     runs-on: ubuntu-latest
     steps:
+      - name: install dependencies
+        run: python -m pip install ninja meson
       - uses: actions/checkout@v4
         with:
           path: tmp
@@ -39,8 +41,6 @@ jobs:
           repository: JeffersonLab/clas12-mcgen # only the main fork has tags
           ref: ${{ steps.tag.outputs.tag }}
           submodules: recursive
-      - name: install dependencies
-        run: sudo apt -y install meson
       - name: build
         run: make clas-stringspinner -j4
       - name: generate documentation


### PR DESCRIPTION
The usage guide for `clas-stringspinner` is auto generated. It's possible its documentation will be ahead of the latest `clas12-mcgen` version's `clas-stringspinner`, thus confusing OSG portal users.

This PR starts a CI config for this repo, and generates `clas-stringspinner` documentation based on the highest `clas12-mcgen` tag (which is assumed to be available on OSG). The link from the OSG portal should point to this documentation.