### PR TITLE
link to "local" LHAPDF data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,10 @@ lib/libLHAPDF.so: dirs
 	$(MAKE) -C LHAPDF-${V}
 	$(MAKE) -C LHAPDF-${V} install
 
-linkcvmfs:
+linkdata:
 	mkdir -p share && rm -rf share/LHAPDF
-	cd share && ln -s /cvmfs/oasis.opensciencegrid.org/jlab/hallb/clas12/sw/noarch/data/LHAPDF
+	cd share && ln -s ../../../../../noarch/data/LHAPDF
+	#cd share && ln -s /cvmfs/oasis.opensciencegrid.org/jlab/hallb/clas12/sw/noarch/data/LHAPDF
 
 lib/liblog4cpp.so: dirs
 	wget --no-check-certificate https://sourceforge.net/projects/log4cpp/files/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.4.tar.gz
@@ -118,7 +119,7 @@ genie: pythia6 lhapdf log4cpp dirs
 	mv -f bin/genie bin/genie.exe
 	$(MAKE) -C genie-util install
 
-install: fixperms linkcvmfs
+install: fixperms linkdata
 	install -D clasdis/clasdis bin/clasdis
 	install -D claspyth/claspyth bin/claspyth
 	install -D dvcsgen/dvcsgen bin/dvcsgen


### PR DESCRIPTION
Better support at least the first 2 options:
1. full install
1. relative local link
1. absolute /cvmfs link