### PR TITLE
feat: `make slim` for minimizing installation size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,33 @@ prune:
 	rm -rf LHAPDF* log4cpp* pythia6* libxml* root-* build onepigen/spp_tbl.tar.gz clas-stringspinner/build
 	make -C gibuu prune
 
+slim: prune
+	rm -rf .git
+	for dir in $(SUBMODULES); do\
+		rm -rf $$dir/.git; \
+	done
+	rm -rf pythia8
+	rm -rf clas-stringspinner
+	rm -rf clas12-elSpectro/elSpectro/jpacPhoto/lib
+	rm -f clasdis/clasdis
+	rm -f claspyth/claspyth
+	rm -f dvcsgen/dvcsgen
+	rm -f genKYandOnePion/genKYandOnePion
+	rm -f inclusive-dis-rad/inclusive-dis-rad
+	rm -f JPsiGen/JPsiGen.exe
+	rm -f JPsiGen/JPsiGen
+	rm -f twopeg/twopeg
+	rm -f JPsiGen/lib/libJPsiGen.so
+	rm -f TCSGen/TCSGen.exe
+	rm -f TCSGen/TCSGen
+	rm -f TCSGen/lib/libTCSGen.so
+	rm -f MCEGENpiN_radcorr/MCEGENpiN_radcorr
+	rm -f deep-pipi-gen/deep-pipi-gen
+	rm -f genepi/genepi
+	rm -f generate-seeds.py
+	rm -f onepigen/onepigen
+	rm -f onepigen/onepigen_lund
+
 debug:
 	@ echo SUBMODULES: $(SUBMODULES)
 	@ echo CLEANDIRS:  $(CLEANDIRS)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ MAKEDIRS := $(filter-out test,$(MAKEDIRS))
 TOP := $(shell pwd)
 PATH := $(TOP)/bin:$(PATH)
 
+unexport CMAKE_GENERATOR
 export GENIE := $(TOP)/genie
 
 all: gibuu twopeg elspectro clas-stringspinner simple

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ clean:
 
 prune:
 	rm -rf LHAPDF* log4cpp* pythia6* libxml* root-* build onepigen/spp_tbl.tar.gz clas-stringspinner/build
+	make -C gibuu prune
 
 debug:
 	@ echo SUBMODULES: $(SUBMODULES)


### PR DESCRIPTION
- add `make slim`, for _**destructively**_ slimming the repository
  - removes some source code, things that are duplicated, `.git` directories
- disk usage:
  - after `make && make install`: 1,548,280 B
  - after `make prune`: 1,450,312 B
  - after `make slim`: 955,508 B
- also fixes #56