### PR TITLE
ci: remove `CMAKE_POLICY_VERSION_MINIMUM` setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  CMAKE_POLICY_VERSION_MINIMUM: 3.5 # kluge for cmake v4 support
-
 jobs:
   build:
     name: build and test


### PR DESCRIPTION
since it's now done in the Makefile where needed, just for `elspectro`

closes #58 